### PR TITLE
Command vm

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,14 +4,25 @@ import (
 	"fmt"
 )
 
-// Run will execute the command with provided arguments.
+// Run executes the specified command.
 func Run(args []string) int {
 	if len(args) == 0 {
 		help()
 		return 0
 	}
 
-	return 0
+	cmds := map[string]func([]string) int{
+		"vm": func(a []string) int { return vmRun(a) },
+	}
+
+	cmd, ok := cmds[args[0]]
+	if !ok {
+		fmt.Println("No such cmd:", args[0])
+		help()
+		return 1
+	}
+
+	return cmd(args[1:])
 }
 
 // help shows the usage information.
@@ -20,6 +31,7 @@ func help() {
 Usage: rcstate <command> [args]
 
 Commands:
+  vm      manage state of virtual machine instances
 `
 	fmt.Println(text)
 }

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -1,0 +1,11 @@
+package cmd
+
+// vmRun executes the command 'vm'.
+func vmRun(args []string) int {
+	if len(args) == 0 {
+		help()
+		return 0
+	}
+
+	return vmHelp()
+}

--- a/cmd/vm_help.go
+++ b/cmd/vm_help.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "fmt"
+
+// vmHelp prints the usage information for the command 'vm'.
+func vmHelp() int {
+	text := `
+vm command usage:
+  rcstate vm <argument> [option...]
+
+Arguments:
+  help      show usage
+
+Options:
+`
+	fmt.Println(text)
+
+	return 0
+}


### PR DESCRIPTION
Develop the command `vm` to manage the state of Virtual Machine instances.

The command `vm` should return an integer which represent the exit status code.