### PR TITLE
Argument start for command vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,10 @@ go install github.com/marintailor/rcstate@latest
 rcstate vm list \
   --project <project_name> \
   --zone <zone_name>
+
+# start an instance in specific project and zone
+rcstate vm start \
+  --name <instance_name> \
+  --project <project_name> \
+  --zone <zone_name>
 ```

--- a/api/gce/gce_vm.go
+++ b/api/gce/gce_vm.go
@@ -131,3 +131,30 @@ func getInstanceDetails(inst *computepb.Instance) Instance {
 func (i *Instances) addInstance(inst Instance) {
 	i.List = append(i.List, inst)
 }
+
+// Start will start an instance.
+func (i *Instances) Start(inst string) error {
+	ctx := context.Background()
+	instancesClient, err := compute.NewInstancesRESTClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewInstancesRESTClient: %w", err)
+	}
+	defer instancesClient.Close()
+
+	req := &computepb.StartInstanceRequest{
+		Project:  i.Project,
+		Zone:     i.Zone,
+		Instance: inst,
+	}
+
+	op, err := instancesClient.Start(ctx, req)
+	if err != nil {
+		return fmt.Errorf("start instance: %w", err)
+	}
+
+	if err = op.Wait(ctx); err != nil {
+		return fmt.Errorf("wait operation: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -15,6 +15,7 @@ type VirtualMachine struct {
 
 // options stores options from parsed flags.
 type options struct {
+	name    string
 	project string
 	zone    string
 }
@@ -33,18 +34,19 @@ func vmRun(args []string) int {
 		return 1
 	}
 
-	commands := map[string]func() int{
-		"list": func() int { return vm.list() },
+	cmds := map[string]func() int{
+		"list":  func() int { return vm.list() },
+		"start": func() int { return vm.start() },
 	}
 
-	command, ok := commands[args[0]]
+	cmd, ok := cmds[args[0]]
 	if !ok {
-		fmt.Println("No such command: vm", args[0])
+		fmt.Println("no such command: vm", args[0])
 		help()
 		return 1
 	}
 
-	return command()
+	return cmd()
 }
 
 // NewVirtualMachine returns a VirtualMachine struct.
@@ -63,6 +65,9 @@ func NewVirtualMachine(args []string) (*VirtualMachine, error) {
 // getOptions will parse flags for options.
 func (v *VirtualMachine) getOptions(args []string) error {
 	f := flag.NewFlagSet(args[0], flag.ExitOnError)
+
+	f.StringVar(&v.Opts.name, "name", "", "Virtual Machine instance name")
+	f.StringVar(&v.Opts.name, "n", "", "Virtual Machine instance name")
 
 	f.StringVar(&v.Opts.project, "project", "", "Google Cloud Project ID")
 	f.StringVar(&v.Opts.project, "p", "", "Google Cloud Project ID")

--- a/cmd/vm_help.go
+++ b/cmd/vm_help.go
@@ -11,8 +11,11 @@ vm command usage:
 Arguments:
   help      show usage
   list      list virtual machines
+  start     start the virtual machine
 
 Options:
+  -n, --name           virtual machine name
+
   -p, --project        Google Cloud Project ID
 
   -z, --zone           Google Cloud Zone name
@@ -22,6 +25,14 @@ Examples:
   List all instances in specific project and zone
 
     rcstate vm list \
+      --project <project_name> \
+      --zone <zone_name>
+
+
+  Start an instance in specific project and zone
+
+    rcstate vm start \
+      --name <instance_name> \
       --project <project_name> \
       --zone <zone_name>
 `

--- a/cmd/vm_start.go
+++ b/cmd/vm_start.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+// start will start an instance.
+func (v VirtualMachine) start() int {
+	if v.Opts.name == "" {
+		fmt.Println("Please provide the instance's name.")
+		return 1
+	}
+
+	fmt.Printf("=== Start instance %q\n", v.Opts.name)
+	if err := v.Instances.Start(v.Opts.name); err != nil {
+		fmt.Printf("Could not start instance %q: %v\n", v.Opts.name, err)
+		return 1
+	}
+
+	fmt.Printf("=== Done\n\n")
+
+	return 0
+}


### PR DESCRIPTION
Argument start is used for command vm to start a virtual machine instance.

Three required options are provided as flags:

- name - virtual machine instance's name
- project - Google Cloud Project ID
- zone - Google Cloud Zone name