### PR TITLE
Argument stop for command vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,10 @@ rcstate vm status \
   --name <instance_name> \
   --project <project_name> \
   --zone <zone_name>
+
+# stop an instance in specific project and zone
+rcstate vm stop \
+  --name <instance_name> \
+  --project <project_name> \
+  --zone <zone_name>
 ```

--- a/api/gce/gce_vm.go
+++ b/api/gce/gce_vm.go
@@ -175,3 +175,30 @@ func (i *Instances) Status(inst string) (string, error) {
 
 	return resp.Status, nil
 }
+
+// Stop will stop the instance.
+func (i *Instances) Stop(inst string) error {
+	ctx := context.Background()
+	instancesClient, err := compute.NewInstancesRESTClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewInstancesRESTClient: %w", err)
+	}
+	defer instancesClient.Close()
+
+	req := &computepb.StopInstanceRequest{
+		Project:  i.Project,
+		Zone:     i.Zone,
+		Instance: inst,
+	}
+
+	op, err := instancesClient.Stop(ctx, req)
+	if err != nil {
+		return fmt.Errorf("stop instance: %w", err)
+	}
+
+	if err = op.Wait(ctx); err != nil {
+		return fmt.Errorf("wait operation: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -38,6 +38,7 @@ func vmRun(args []string) int {
 		"list":   func() int { return vm.list() },
 		"start":  func() int { return vm.start() },
 		"status": func() int { return vm.status() },
+		"stop":   func() int { return vm.stop() },
 	}
 
 	cmd, ok := cmds[args[0]]

--- a/cmd/vm_help.go
+++ b/cmd/vm_help.go
@@ -13,6 +13,7 @@ Arguments:
   list      list virtual machines
   start     start the virtual machine
   status    show status of the virtual machine
+  stop      stop the virtual machine
 
 Options:
   -n, --name           virtual machine name
@@ -41,6 +42,14 @@ Examples:
   Show status of an instance in specific project and zone
 
     rcstate vm status \
+      --name <instance_name> \
+      --project <project_name> \
+      --zone <zone_name>
+
+
+  Stop an instance in specific project and zone
+
+    rcstate vm stop \
       --name <instance_name> \
       --project <project_name> \
       --zone <zone_name>

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+// stop will stop an instance.
+func (v VirtualMachine) stop() int {
+	if v.Opts.name == "" {
+		fmt.Println("Please provide the instance's name.")
+		return 1
+	}
+
+	fmt.Printf("=== Stop instance %q\n", v.Opts.name)
+	if err := v.Instances.Stop(v.Opts.name); err != nil {
+		fmt.Printf("stop instance %q: %v\n", v.Opts.name, err)
+		return 1
+	}
+
+	fmt.Printf("=== Done\n\n")
+
+	return 0
+}


### PR DESCRIPTION
Argument `stop` is used for command `vm` to stop a virtual machine instance.

Three required options are provided as flags:

- name - virtual machine instance's name
- project - Google Cloud Project ID
- zone - Google Cloud Zone name