### PR TITLE
Run shell commands on remote instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,31 @@ rcstate vm start \
   --name <instance_name> \
   --project <project_name> \
   --zone <zone_name> \
-  --domain <dns_domain>
+  --domain <dns_domain> \
   --dns-record-name <record_name> \
   --dns-record-type <record_type>
+
+# start an instance and run shell commands AFTER the instance is started
+rcstate vm start \
+  --name <instance_name> \
+  --project <project_name> \
+  --zone <zone_name> \
+  --script "echo TEST > test-file" \
+  --ip <ip_addr> \
+  --ssh-key <path_to_key> \
+  --ssh-port <port_number> \
+  --ssh-user <username>
+
+# stop an instance and run shell commands BEFORE the instance is stopped
+rcstate vm stop \
+  --name <instance_name> \
+  --project <project_name> \
+  --zone <zone_name> \
+  --script "echo TEST > test-file" \
+  --ip <ip_addr> \
+  --ssh-key <path_to_key> \
+  --ssh-port <port_number> \
+  --ssh-user <username>
 
 # show status of an instance in specific project and zone
 rcstate vm status \

--- a/api/ssh/ssh.go
+++ b/api/ssh/ssh.go
@@ -1,0 +1,121 @@
+package ssh
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// SSH stores required SSH configuration.
+type SSH struct {
+	conf *ssh.ClientConfig
+	Host string
+	Key  string
+	Port string
+	User string
+}
+
+// NewSSH return a SSH struct.
+func NewSSH(host string, port string, user string, keyPath string) (*SSH, error) {
+	if err := checkSSHArgs(host, port, user, keyPath); err != nil {
+		return nil, fmt.Errorf("check ssh args: %w", err)
+	}
+
+	if _, err := os.Stat(keyPath); err != nil {
+		return nil, fmt.Errorf("ssh key stat %q: %w", keyPath, err)
+	}
+
+	keyData, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read ssh key: %w", err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(keyData)
+	if err != nil {
+		return nil, fmt.Errorf("parse key: %w", err)
+	}
+
+	hostKeyCallback, err := knownhosts.New("/Users/marin/.ssh/known_hosts")
+	if err != nil {
+		return nil, fmt.Errorf("host key callback: %w", err)
+	}
+
+	conf := &ssh.ClientConfig{
+		User:            user,
+		HostKeyCallback: hostKeyCallback,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+	}
+
+	return &SSH{
+		conf: conf,
+		Host: host,
+		Key:  keyPath,
+		Port: port,
+		User: user,
+	}, nil
+}
+
+// checkSSHArgs ensures that complete SSH configuration is provided.
+func checkSSHArgs(host string, port string, user string, keyPath string) error {
+	if host == "" {
+		return fmt.Errorf("host value is empty")
+	}
+	if port == "" {
+		return fmt.Errorf("port value is empty")
+	}
+	if user == "" {
+		return fmt.Errorf("user value is empty")
+	}
+	if keyPath == "" {
+		return fmt.Errorf("key path value is empty")
+	}
+
+	return nil
+}
+
+// CMD executes shell commands over SSH connection.
+func (s *SSH) CMD(cmd string) error {
+	dest := fmt.Sprintf("%s:%s", s.Host, s.Port)
+	conn, err := ssh.Dial("tcp", dest, s.conf)
+	if err != nil {
+		return fmt.Errorf("ssh dial: %w", err)
+	}
+	defer conn.Close()
+
+	session, err := conn.NewSession()
+	if err != nil {
+		return fmt.Errorf("new session: %w", err)
+	}
+	defer session.Close()
+
+	stdOut, err := session.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("STDOUT pipe: %w", err)
+	}
+
+	stdErr, err := session.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("STDERR pipe: %w", err)
+	}
+
+	if err := session.Run(cmd); err != nil {
+		scannerErr := bufio.NewScanner(stdErr)
+		for scannerErr.Scan() {
+			fmt.Println(scannerErr.Text())
+		}
+
+		return fmt.Errorf("run cmd: %w", err)
+	}
+
+	scannerOut := bufio.NewScanner(stdOut)
+	for scannerOut.Scan() {
+		fmt.Println(scannerOut.Text())
+	}
+
+	return nil
+}

--- a/cmd/vm_help.go
+++ b/cmd/vm_help.go
@@ -31,6 +31,15 @@ Options:
 
   -p, --project        Google Cloud Project ID
 
+  -s, --script         Run shell command(s) on virtual machine with SSH connection
+                       NOTE: command(s) must be wrapped in double quotes
+
+  --ssh-key            Path to private key for SSH connection
+
+  --ssh-port           Port number for SSH connection
+
+  --ssh-user           Username for SSH connection
+
   -z, --zone           Google Cloud Zone name
 
 Examples:
@@ -49,6 +58,7 @@ Examples:
       --project <project_name> \
       --zone <zone_name>
 
+
   Start an instance in specific project and zone, and create a DNS record
 
     rcstate vm start \
@@ -58,6 +68,7 @@ Examples:
       --domain <dns_domain> \
       --dns-record-name <record_name> \
       --dns-record-type <record_type>
+
 
   Show status of an instance in specific project and zone
 
@@ -73,6 +84,32 @@ Examples:
       --name <instance_name> \
       --project <project_name> \
       --zone <zone_name>
+
+
+  Start an instance and run shell commands AFTER the instance is started
+
+    rcstate vm start \
+      --name <instance_name> \
+      --project <project_name> \
+      --zone <zone_name> \
+      --script "echo TEST > test-file" \
+      --ip <ip_addr> \
+      --ssh-key <path_to_key> \
+      --ssh-port <port_number> \
+      --ssh-user <username>
+
+
+  Stop an instance and run shell commands BEFORE the instance is stopped
+
+    rcstate vm stop \
+      --name <instance_name> \
+      --project <project_name> \
+      --zone <zone_name> \
+      --script "echo TEST > test-file" \
+      --ip <ip_addr> \
+      --ssh-key <path_to_key> \
+      --ssh-port <port_number> \
+      --ssh-user <username>
 `
 	fmt.Println(text)
 

--- a/cmd/vm_start.go
+++ b/cmd/vm_start.go
@@ -23,6 +23,11 @@ func (v VirtualMachine) start() int {
 		v.record(dnsRecord)
 	}
 
+	if v.Opts.script.cmd != "" {
+		fmt.Println("=== Execute shell script")
+		v.script()
+	}
+
 	fmt.Printf("=== Done\n\n")
 
 	return 0

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -11,6 +11,11 @@ func (v VirtualMachine) stop() int {
 		return 1
 	}
 
+	if v.Opts.script.cmd != "" {
+		fmt.Println("=== Execute shell script")
+		v.script()
+	}
+
 	fmt.Printf("=== Stop instance %q\n", v.Opts.name)
 	if err := v.Instances.Stop(v.Opts.name); err != nil {
 		fmt.Printf("stop instance %q: %v\n", v.Opts.name, err)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/compute v1.20.0
 	github.com/aws/aws-sdk-go v1.44.278
+	golang.org/x/crypto v0.9.0
 	golang.org/x/oauth2 v0.8.0
 	google.golang.org/api v0.125.0
 )
@@ -19,7 +20,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.10.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,7 @@ golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.8.0 h1:n5xxQn2i3PC0yLAbjTpNT85q/Kgzcr2gIoX9OrJUols=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
Functionality to run shell commands on remote instance by providing commands with flag `script`.

To run commands the following required flags must be:

- script - one or more shell commands
- ip - IP address of the instance
- ssh-key - path to the SSH private key
- ssh-port - SSH port
- ssh-user - SSH username