### PR TITLE
Argument show for command env

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,42 @@ go install github.com/marintailor/rcstate@latest
 
 ## Usage
 
+### Manage environments
+
+An environment represents one or more groups of resources that are already present in the Public Cloud.
+
+The environments are declared in a YAML file, and it is provided as an option with flag `--env-file`.
+
+```bash
+rcstate env show --all --env-file env-dev.yaml
+```
+
+**Examples:**
+
+```bash
+# show an environment
+rcstate env show \
+  --name <environment_name> \
+  --env-file <environment_file>
+
+# show all environments
+rcstate env show \
+  --all \
+  --env-file <environment_file>
+
+# show an environments with label "api"
+rcstate env show \
+  --name <environment_name> \
+  --label api \
+  --env-file <environment_file>
+
+# show all environments with label "api"
+rcstate env show \
+  --all \
+  --label api \
+  --env-file <environment_file>
+```
+
 ### Google Cloud Engine virtual machine
 
 ```bash

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"text/template"
 
 	"gopkg.in/yaml.v3"
@@ -95,7 +96,10 @@ func envRun(args []string) int {
 		return 1
 	}
 
-	commands := map[string]func() int{}
+	commands := map[string]func() int{
+		"help": func() int { return envHelp() },
+		"show": func() int { return envs.show() },
+	}
 
 	command, ok := commands[args[0]]
 	if !ok {
@@ -203,4 +207,41 @@ func (e *Environments) environmentTemplate(ef string) (bytes.Buffer, error) {
 	}
 
 	return d, nil
+}
+
+// getEnvironment will return a specific environment.
+func (e *Environments) getEnvironment(name string) (Environment, error) {
+	for _, env := range e.Envs {
+		if env.Name == name {
+			return env, nil
+		}
+	}
+
+	return Environment{}, fmt.Errorf("environment %q present", name)
+}
+
+// checkLabel will check if a specific environment is labeled with provided labels.
+func (env *Environment) checkLabel(label string) bool {
+	if label == "" {
+		return true
+	}
+
+	if env.Label == "" && label != "" {
+		return false
+	}
+
+	labelList := strings.Split(label, ",")
+	labelNumber := len(labelList)
+
+	var count int
+	for _, l := range labelList {
+		envLabel := strings.Split(env.Label, ",")
+		for _, el := range envLabel {
+			if el == l {
+				count++
+			}
+		}
+	}
+
+	return labelNumber == count
 }

--- a/cmd/env_help.go
+++ b/cmd/env_help.go
@@ -10,8 +10,30 @@ env command usage:
 
 Arguments:
   help    show usage
+  show    show environment
 
 Options:
+  -a, --all        show all environments
+                   option is ignored when option "name" if provided
+
+  -e, -env-file    environment file
+
+  -n, -name        environment name
+
+Examples:
+  Show all environments:
+
+    rcstate env show -a -e <env_file>
+
+
+  Show an environment:
+
+    rcstate env show -n <env_name> -e <env_file>
+
+
+  Show all environments or an environment with specific label(s):
+
+    rcstate env show {-a | -n <env_name> } -l dev -e <env_file>
 `
 	fmt.Println(text)
 

--- a/cmd/env_show.go
+++ b/cmd/env_show.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/marintailor/rcstate/api/gce"
+)
+
+// down will show all resources in environments.
+func (e *Environments) show() int {
+	switch {
+	case e.name != "":
+		env, err := e.getEnvironment(e.name)
+		if err != nil {
+			fmt.Println(err)
+			return 1
+		}
+
+		if !env.checkLabel(e.label) {
+			fmt.Printf("environment %q is not labeled with %q\n", e.name, e.label)
+			return 1
+		}
+
+		showEnvironment(env)
+
+		return 0
+	case e.all:
+		var count int
+
+		for _, env := range e.Envs {
+			if !env.checkLabel(e.label) {
+				continue
+			}
+
+			showEnvironment(env)
+
+			count++
+		}
+
+		if len(e.Envs) > 0 && count == 0 {
+			fmt.Printf("no environment is labeled with %q\n", e.label)
+		}
+	}
+
+	return 0
+}
+
+// showEnvironment will show all resources in specific environment.
+func showEnvironment(env Environment) {
+	fmt.Printf("\n%s\nENVIRONMENT: %s\n%s\n", strings.Repeat("=", 40), env.Name, strings.Repeat("=", 40))
+	for i, g := range env.Group {
+		if i > 0 {
+			fmt.Println(strings.Repeat("-", 40))
+		}
+
+		fmt.Printf("\nGROUP: %s\nPROJECT: %s\nZONE: %s\n\n", g.Name, g.Project, g.Zone)
+		fmt.Printf("VIRTUAL MACHINES\n")
+
+		pw := padWidth(g.Resource.VM.Instance)
+
+		list, err := gce.NewInstances(g.Project, g.Zone).GetList()
+		if err != nil {
+			fmt.Printf("new instances: %v", err)
+		}
+
+		for j, instance := range g.Resource.VM.Instance {
+			var status string
+			for _, inst := range list {
+				if inst.Name == instance.Name {
+					status = inst.Status
+				}
+			}
+			padding := strings.Repeat(" ", pw-len(instance.Name))
+			fmt.Printf("%d. %s%sStatus: %s\n", j+1, instance.Name, padding, status)
+		}
+		fmt.Println()
+	}
+}
+
+// padWidth returns width of the pad.
+func padWidth(instances []Instance) int {
+	pw := 16
+	for _, instance := range instances {
+		if len(instance.Name) >= pw {
+			pw = len(instance.Name) + 2
+		}
+	}
+
+	return pw
+}


### PR DESCRIPTION
Argument `show` is used for command `env` which will show environment declared in the environment file.